### PR TITLE
xadmaster.library: use AROS types as base for XAD types.

### DIFF
--- a/workbench/libs/xad/amiga/include/C/libraries/xadmaster.h
+++ b/workbench/libs/xad/amiga/include/C/libraries/xadmaster.h
@@ -42,6 +42,17 @@ extern "C" {
 
 #define XADM
 
+#ifdef __AROS__
+typedef ULONG              xadUINT32;
+typedef LONG               xadINT32;
+typedef UWORD              xadUINT16;
+typedef WORD               xadINT16;
+typedef UBYTE              xadUINT8;
+typedef BYTE               xadINT8;
+typedef ULONG              xadSize;
+typedef LONG               xadSignSize;
+typedef IPTR               xadIPTR;
+#else
 #ifdef HAVE_STDINT_H
 #include <stdint.h>
 typedef uint32_t           xadUINT32;
@@ -63,6 +74,7 @@ typedef signed char        xadINT8;
 typedef xadUINT32          xadSize;
 typedef xadINT32           xadSignSize;
 typedef unsigned long      xadIPTR;
+#endif
 #endif
 typedef void *             xadPTR;
 typedef char               xadSTRING;


### PR DESCRIPTION
This fixes a crash on x86_64 as reported here:
https://sourceforge.net/p/aros/bugs/508/

Reason for crash:
Because xad(U)INT32 was defined as long the segment scanner was confused by the padding bytes.

Tested with one LHA and one ZIP file.